### PR TITLE
Updates deploy to fix bug with external DB on OCP

### DIFF
--- a/scripts/destroy-sonarqube.sh
+++ b/scripts/destroy-sonarqube.sh
@@ -14,4 +14,6 @@ fi
 kubectl delete all,deployment,statefulset,secret,configmap,service,ingress,pvc -n "${NAMESPACE}" -l "app=${APP_NAME}"
 
 echo "Destroying postgres db"
-kubectl delete all,deploymentconfig,service,secret,pvc -l "tools=${APP_NAME}" -n "${NAMESPACE}"
+kubectl delete all,deploymentconfig,service,secret,pvc -l "tools=sonarqube,app=${APP_NAME}" -n "${NAMESPACE}"
+
+exit 0


### PR DESCRIPTION
- Only install postres in-cluster on OpenShift if external values not provided
- Use the app and tools label when uninstalling in-cluster postgres

ibm-garage-cloud/planning#345